### PR TITLE
Typo in .env-File

### DIFF
--- a/traefik/example.env
+++ b/traefik/example.env
@@ -2,6 +2,6 @@ APP_URL=traefik.domain.tld
 APP_AUTH=secretGeneratedWith:htpasswd
 MAIN_DOMAIN=domain.tld
 ALT_DOMAIN=altdomain.tld
-ALT_DOAMIN2=altdomain2.tld
+ALT_DOMAIN2=altdomain2.tld
 GANDIV5_API_KEY=secret
 LOCAL_IP_RANGE=192.168.0.0/16


### PR DESCRIPTION
Misspelled ALT_DOMAIN2=